### PR TITLE
詳細表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,9 +21,9 @@ class Item < ApplicationRecord
   validates :shipping_cost_information_id, numericality: { other_than: 1, message: "can't be blank!!!" }
   validates :shipping_origin_information_id, numericality: { other_than: 1, message: "can't be blank!!!!" }
   validates :shipping_time_id, numericality: { other_than: 1, message: "can't be blank!!!!!" }
-  has_one :purchase_record
+  # has_one :purchase_record
 
-  def sold_out?
-    purchase_record.present?
-  end
+  # def sold_out?
+  #  purchase_record.present?
+  # end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,4 +21,9 @@ class Item < ApplicationRecord
   validates :shipping_cost_information_id, numericality: { other_than: 1, message: "can't be blank!!!" }
   validates :shipping_origin_information_id, numericality: { other_than: 1, message: "can't be blank!!!!" }
   validates :shipping_time_id, numericality: { other_than: 1, message: "can't be blank!!!!!" }
+  has_one :purchase_record
+
+  def sold_out?
+    purchase_record.present?
+  end
 end

--- a/app/models/purchase_record.rb
+++ b/app/models/purchase_record.rb
@@ -1,0 +1,3 @@
+class PurchaseRecord < ApplicationRecord
+  belongs_to :items
+end

--- a/app/models/purchase_record.rb
+++ b/app/models/purchase_record.rb
@@ -1,3 +1,3 @@
 class PurchaseRecord < ApplicationRecord
-  belongs_to :items
+  # belongs_to :items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   validates :given_name_yomi, presence: true, format: { with: /\A[ァ-ヶー]+\z/ }
   validates :date_of_birth, presence: true
 
-  validate :pricing_information_must_be_half_width_numeric
+  # validate :pricing_information_must_be_half_width_numeric
 
   private
 
@@ -29,9 +29,9 @@ class User < ApplicationRecord
     errors.add :password, 'は英数字をそれぞれ含める必要があります'
   end
 
-  def pricing_information_must_be_half_width_numeric
-    return if pricing_information.to_s.match?(/\A[0-9]+\z/)
+  # def pricing_information_must_be_half_width_numeric
+  # return if pricing_information.to_s.match?(/\A[0-9]+\z/)
 
-    errors.add(:pricing_information, 'は半角数字のみを含む場合でなければなりません')
-  end
+  # errors.add(:pricing_information, 'は半角数字のみを含む場合でなければなりません')
+  # end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -163,7 +163,7 @@
 
 
       <li class='list'>
-        <%= link_to new_item_path do %>
+        <%= link_to "#" do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,9 +131,10 @@
       <% @items.each do |item| %>
   
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
+
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -162,7 +163,7 @@
 
 
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to new_item_path do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,13 +9,13 @@
     <div class="item-img-content">
 <%= image_tag @item.image, class: "item-box-img" if @item.image.attached? %>
 
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <% if @item.sold_out? %>
+      
+      <%# if @item.sold_out? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# end %>
+
 
     </div>
     <div class="item-price-box">
@@ -27,28 +27,27 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    
   <% if user_signed_in? %>
-  <p>ユーザーがログインしています。</p>
+
     <% if current_user == @item.user %>
-  <p>出品者本人です。</p>
+
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
    <% else %>
-   <p>出品者本人ではありません。</p>
-   <% if !@item.sold_out? %>
-   <p>商品は売り切れていません。購入ボタンを表示します。</p>
+
+   <%# if !@item.sold_out? %>
+
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-        <% else %>
-      <p>商品は売り切れています。</p>
+     <%# else %>
+
     <% end %>
-  <% end %>
+  <%# end %>
 <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -116,9 +115,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+ 
+  <a href="#" class="another-item"><%= @item.category_information.name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,50 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+<%= image_tag @item.image, class: "item-box-img" if @item.image.attached? %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.sold_out? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       ¥ <%= @item.pricing_information%>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost_information.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
+  <% if user_signed_in? %>
+  <p>ユーザーがログインしています。</p>
+    <% if current_user == @item.user %>
+  <p>出品者本人です。</p>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
+   <% else %>
+   <p>出品者本人ではありません。</p>
+   <% if !@item.sold_out? %>
+   <p>商品は売り切れていません。購入ボタンを表示します。</p>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+        <% else %>
+      <p>商品は売り切れています。</p>
+    <% end %>
+  <% end %>
+<% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
@@ -44,27 +57,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nick_name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category_information.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.product_condition_information.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost_information.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_origin_information.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_time.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -50,7 +50,7 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.product_description%></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/db/migrate/20241229070850_create_purchase_records.rb
+++ b/db/migrate/20241229070850_create_purchase_records.rb
@@ -1,0 +1,9 @@
+class CreatePurchaseRecords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :purchase_records do |t|
+      t.references :item, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_22_090741) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_29_070850) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -67,6 +67,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_090741) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "purchase_records", charset: "utf8", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_purchase_records_on_item_id"
+    t.index ["user_id"], name: "index_purchase_records_on_user_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -88,4 +97,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_090741) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchase_records", "items"
+  add_foreign_key "purchase_records", "users"
 end

--- a/spec/factories/purchase_records.rb
+++ b/spec/factories/purchase_records.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchase_record do
+    item { nil }
+  end
+end

--- a/spec/models/purchase_record_spec.rb
+++ b/spec/models/purchase_record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseRecord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
＃what
商品の詳細ページを追加しました。
#why
商品の購入を検討する際に、ユーザーに対して商品説明や価格などの重要な情報を提示するため。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/3bea09eb18a765bddb81bc5a6a445782
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/372502137d3af48489c53900d191c39f
ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/f90d2aba6cf5db6e5c175cd0ce573e57